### PR TITLE
Add EIA API Data Fetching Service and Grid-Mix Endpoint

### DIFF
--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -1,7 +1,41 @@
 from fastapi import APIRouter
+from services.eia_service import get_eia_grid_mix_timeseries
 
 router = APIRouter()
 
 @router.get("/health")
 def health_check():
     return {"status": "FastAPI is running!"}
+
+@router.get("/grid-mix")
+def fetch_grid_mix(
+    balancing_authority: str = Query(..., description="Balancing Authority ID")
+):
+    """
+    API endpoint to fetch electricity generation data by fuel type.
+
+    Parameters:
+    - balancing_authority (str): The balancing authority ID for which to fetch electricity generation data.
+
+    Returns:
+    - JSON: A list of records, where each record contains:
+        - "timestamp" (str): The date of the data point in ISO format.
+        - "Generation (MWh)" (float): The electricity generation in megawatt-hours.
+
+    Example Request:
+        GET /grid-mix?balancing_authority=CISO
+
+    Example Response:
+    [
+        {
+            "timestamp": "2025-03-15T00:00:00",
+            "Generation (MWh)": 1200.5
+        },
+        {
+            "timestamp": "2025-03-14T00:00:00",
+            "Generation (MWh)": 1100.3
+        }
+    ]
+    """
+    data = get_eia_grid_mix_timeseries([balancing_authority])
+    return data.to_dict(orient="records") # Convert DataFrame to JSON

--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Query
-from services.eia_service import get_eia_grid_mix_timeseries
+from backend.services.eia_service import get_eia_grid_mix_timeseries
 
 router = APIRouter()
 

--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from services.eia_service import get_eia_grid_mix_timeseries
 
 router = APIRouter()

--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, HTTPException
+import logging
+import pandas as pd
 from backend.services.eia_service import get_eia_grid_mix_timeseries
 
 router = APIRouter()
@@ -37,5 +39,14 @@ def fetch_grid_mix(
         }
     ]
     """
-    data = get_eia_grid_mix_timeseries([balancing_authority])
-    return data.to_dict(orient="records") # Convert DataFrame to JSON
+    try:
+        data = get_eia_grid_mix_timeseries([balancing_authority])
+
+        if data.empty:
+            raise HTTPException(status_code=404, detail="No data found for the given balancing authority.")
+
+        return data.to_dict(orient="records")  # Convert DataFrame to JSON
+    
+    except Exception as e:
+        logging.error(f"Unexpected error: {e}")
+        raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from api.endpoints import router
+from backend.api.endpoints import router
 
 app = FastAPI(title="EIA Electricity Data API")
 

--- a/backend/services/eia_service.py
+++ b/backend/services/eia_service.py
@@ -3,7 +3,7 @@ import json
 import requests
 import pandas as pd
 import logging
-from config import EIA_API_KEY
+from backend.config import EIA_API_KEY
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")

--- a/backend/services/eia_service.py
+++ b/backend/services/eia_service.py
@@ -1,0 +1,120 @@
+import datetime
+import json
+import requests
+import pandas as pd
+import logging
+from config import EIA_API_KEY
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+# Default time range for API calls
+default_end_date = datetime.date.today().isoformat()
+default_start_date = (datetime.date.today() - datetime.timedelta(days=365)).isoformat()
+
+def get_eia_timeseries(
+    url_segment,
+    facets,
+    value_column_name="value",
+    start_date=default_start_date,
+    end_date=default_end_date,
+    start_page=0,
+):
+    """
+    Fetches time series data from the EIA API, handling pagination and data transformation.
+
+    Parameters:
+        url_segment (str): The specific endpoint for the data type.
+        facets (dict): Filtering options such as balancing authorities.
+        value_column_name (str): The name to assign to the retrieved data column.
+        start_date (str): Start date for the query (ISO format).
+        end_date (str): End date for the query (ISO format).
+        start_page (int): The pagination offset.
+
+    Returns:
+        pd.DataFrame: A cleaned pandas DataFrame containing the fetched time series data.
+    """
+    max_row_count = 5000  # Maximum allowed rows per API call
+    api_url = f"https://api.eia.gov/v2/electricity/rto/{url_segment}/data/?api_key={EIA_API_KEY}"
+    offset = start_page * max_row_count
+
+    logging.info(f"Fetching data from: {api_url}")
+
+    response_content = requests.get(
+        api_url,
+        headers={
+            "X-Params": json.dumps(
+                {
+                    "frequency": "daily",
+                    "data": ["value"],
+                    "facets": dict(**{"timezone": ["Pacific"]}, **facets),
+                    "start": start_date,
+                    "end": end_date,
+                    "sort": [{"column": "period", "direction": "desc"}],
+                    "offset": offset,
+                    "length": max_row_count,
+                }
+            )
+        },
+    ).json()
+
+    if "response" in response_content:
+        response_content = response_content["response"]
+    else:
+        logging.error("Invalid API response format")
+        return pd.DataFrame()
+
+    logging.info(f"Fetched {len(response_content['data'])} rows.")
+
+    dataframe = pd.DataFrame(response_content["data"])
+    dataframe["timestamp"] = dataframe["period"].apply(pd.to_datetime, format="%Y/%m/%dT%H")
+    processed_df = dataframe.astype({"value": float}).rename(columns={"value": value_column_name})
+
+    # Pagination logic
+    rows_fetched = len(processed_df) + offset
+    rows_total = int(response_content["total"])
+    if rows_fetched != rows_total:
+        additional_rows = get_eia_timeseries(
+            url_segment=url_segment,
+            facets=facets,
+            value_column_name=value_column_name,
+            start_date=start_date,
+            end_date=end_date,
+            start_page=start_page + 1,
+        )
+        return pd.concat([processed_df, additional_rows])
+    else:
+        return processed_df
+    
+def get_eia_grid_mix_timeseries(balancing_authorities, **kwargs):
+    """
+    Fetches electricity generation data by fuel type for specified balancing authorities.
+    """
+    return get_eia_timeseries(
+        url_segment="daily-fuel-type-data",
+        facets={"respondent": balancing_authorities},
+        value_column_name="Generation (MWh)",
+        **kwargs
+    )
+
+def get_eia_net_demand_and_generation_timeseries(balancing_authorities, **kwargs):
+    """
+    Fetches electricity demand and net generation data for specified balancing authorities.
+    """
+    return get_eia_timeseries(
+        url_segment="daily-region-data",
+        facets={"respondent": balancing_authorities, "type": ["D", "NG", "TI"]},
+        value_column_name="Demand (MWh)",
+        **kwargs
+    )
+
+def get_eia_interchange_timeseries(balancing_authorities, **kwargs):
+    """
+    Fetches electricity interchange data (imports & exports) for specified balancing authorities.
+    """
+    return get_eia_timeseries(
+        url_segment="daily-interchange-data",
+        facets={"toba": balancing_authorities},
+        value_column_name="Interchange (MWh)",
+        **kwargs
+    )

--- a/backend/services/eia_service.py
+++ b/backend/services/eia_service.py
@@ -67,7 +67,7 @@ def get_eia_timeseries(
     logging.info(f"Fetched {len(response_content['data'])} rows.")
 
     dataframe = pd.DataFrame(response_content["data"])
-    dataframe["timestamp"] = dataframe["period"].apply(pd.to_datetime, format="%Y/%m/%dT%H")
+    dataframe["timestamp"] = pd.to_datetime(dataframe["period"], errors="coerce")
     processed_df = dataframe.astype({"value": float}).rename(columns={"value": value_column_name})
 
     # Pagination logic


### PR DESCRIPTION
## Description  
This PR introduces the `eia_service.py` module for fetching data from the EIA API and implements the `/grid-mix` endpoint to retrieve electricity generation data by fuel type.

Resolves #3 

## Key Changes  
- **Added `eia_service.py`**:  
  - Implements `get_eia_timeseries()`, a reusable function for fetching time-series data from the EIA API.  
  - Introduces `get_eia_grid_mix_timeseries()` to retrieve grid mix data for specified balancing authorities.  
  - Added logging for API calls and improved error handling.  
  - Updated timestamp parsing to automatically detect different formats.  

- **Added `/grid-mix` endpoint**:  
  - Allows fetching of electricity generation data filtered by balancing authority.  
  - Returns the API response in JSON format for frontend integration.  

- **Fixed import issues**:  
  - Resolved missing `Query` import in `endpoints.py`.  
  - Adjusted module imports to align with FastAPI best practices.  

## Testing & Verification  
- Successfully tested the `/grid-mix` endpoint using Postman.  
- Verified that API responses contain accurate timestamps and generation values.  

## Next Steps  
- Integrate this API with the frontend for data visualization.  