### PR TITLE
Fetch Grid Data for Selected Balancing Authority

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,43 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Typography, Container, Box } from "@mui/material";
-import Map from "./components/Map";
+// import Map from "./components/Map";
+import type { GridMixEntry } from "./types/gridMix";
 import BalancingAuthSelector from "./components/BalancingAuthSelector";
+import GridMixViewer from "./components/GridMixViewer";
 
-function App() {
+const App: React.FC = () => {
   const [selectedBA, setSelectedBA] = useState<string>("");
+  const [gridMixData, setGridMixData] = useState<GridMixEntry[]>([]);
+  const [loadingGridMix, setLoadingGridMix] = useState(false);
+  const [gridMixError, setGridMixError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedBA) return;
+
+    const fetchGridMix = async () => {
+      setLoadingGridMix(true);
+
+      try {
+        const response = await fetch(
+          `/api/grid-mix?balancing_authority=${selectedBA}`
+        );
+        if (!response.ok) {
+          throw new Error("Failed to fetch grid mix data");
+        }
+
+        const data: GridMixEntry[] = await response.json();
+        setGridMixData(data);
+      } catch (error) {
+        console.error("Error fetching grid mix data:", error);
+        setGridMixError("Failed to load grid mix data");
+        setGridMixData([]);
+      } finally {
+        setLoadingGridMix(false);
+      }
+    };
+
+    fetchGridMix();
+  }, [selectedBA]);
 
   return (
     <Container
@@ -32,10 +65,16 @@ function App() {
       </Box>
 
       <Box sx={{ width: "100%" }}>
-        <Map />
+        <GridMixViewer
+          data={gridMixData}
+          loading={loadingGridMix}
+          error={gridMixError}
+          selectedBA={selectedBA}
+        />
+        {/* <Map /> */}
       </Box>
     </Container>
   );
-}
+};
 
 export default App;

--- a/frontend/src/components/GridMixViewer.tsx
+++ b/frontend/src/components/GridMixViewer.tsx
@@ -1,0 +1,38 @@
+import { Alert, CircularProgress, Paper, Typography } from "@mui/material";
+import type { GridMixEntry } from "../types/gridMix";
+
+type Props = {
+  data: GridMixEntry[];
+  loading: boolean;
+  error: string | null;
+  selectedBA: string;
+};
+
+const GridMixViewer: React.FC<Props> = ({
+  data,
+  loading,
+  error,
+  selectedBA,
+}) => {
+  if (loading) return <CircularProgress sx={{ mt: 2, mb: 2 }} />;
+  if (error) return <Alert severity="error">{error}</Alert>;
+  if (selectedBA && data.length === 0) {
+    return (
+      <Alert severity="info" sx={{ mt: 2, mb: 2 }}>
+        No generation data available for the selected balancing authority.
+      </Alert>
+    );
+  }
+  return (
+    <Paper sx={{ p: 3, mt: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        Grid Mix Data (Raw View)
+      </Typography>
+      <pre style={{ maxHeight: 300, overflow: "auto", textAlign: "left" }}>
+        {JSON.stringify(data.slice(0, 20), null, 2)}
+      </pre>
+    </Paper>
+  );
+};
+
+export default GridMixViewer;

--- a/frontend/src/types/gridMix.ts
+++ b/frontend/src/types/gridMix.ts
@@ -1,0 +1,12 @@
+export type GridMixEntry = {
+  timestamp: string;
+  period: string;
+  respondent: string;
+  "respondent-name": string;
+  fueltype: string;
+  "type-name": string;
+  timezone: string;
+  "timezone-description": string;
+  "Generation (MWh)": number;
+  "value-units": string;
+};


### PR DESCRIPTION
This PR implements functionality to fetch electricity grid mix data from the FastAPI backend based on the user's selected balancing authority and display it in the UI. Closes #22 

## Features

- Sends a GET request to `/api/grid-mix?balancing_authority=...` when a balancing authority is selected
- Stores the response in component state (`gridMixData`)
- Displays a loading spinner while data is being fetched
- Shows an error alert if the request fails
- Shows an informational message if no data is returned
- Renders a raw data preview in the `GridMixViewer` component