### PR TITLE
Display Grid Data in Table 

### DIFF
--- a/frontend/src/components/GridMixTable.tsx
+++ b/frontend/src/components/GridMixTable.tsx
@@ -1,0 +1,68 @@
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableContainer,
+  Paper,
+  Typography,
+} from "@mui/material";
+import type { GridMixEntry } from "../types/gridMix";
+
+type Props = {
+  data: GridMixEntry[];
+};
+
+const GridMixTable: React.FC<Props> = ({ data }) => {
+  if (!data || data.length === 0) return null;
+
+  return (
+    <Paper sx={{ p: 3, mt: 2 }}>
+      <TableContainer component={Paper} sx={{ maxHeight: 400, mt: 2, mb: 2 }}>
+        <Typography variant="h6" sx={{ p: 2 }}>
+          Generation by Fuel Type
+        </Typography>
+        <Table size="small" stickyHeader>
+          <TableHead>
+            <TableRow>
+              <TableCell>Date</TableCell>
+              <TableCell>Fuel Type</TableCell>
+              <TableCell>Generation (MWh)</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.map((entry, index) => (
+              <TableRow key={index}>
+                <TableCell>
+                  {new Date(entry.timestamp).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </TableCell>
+                <TableCell>{entry["type-name"]}</TableCell>
+                <TableCell>
+                  {entry["Generation (MWh)"].toLocaleString()}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Typography
+        variant="caption"
+        sx={{
+          mt: 1,
+          display: "block",
+          textAlign: "right",
+          color: "text.secondary",
+        }}
+      >
+        {data.length.toLocaleString()} rows fetched
+      </Typography>
+    </Paper>
+  );
+};
+
+export default GridMixTable;

--- a/frontend/src/components/GridMixViewer.tsx
+++ b/frontend/src/components/GridMixViewer.tsx
@@ -1,5 +1,6 @@
-import { Alert, CircularProgress, Paper, Typography } from "@mui/material";
+import { Alert, CircularProgress } from "@mui/material";
 import type { GridMixEntry } from "../types/gridMix";
+import GridMixTable from "./GridMixTable";
 
 type Props = {
   data: GridMixEntry[];
@@ -23,16 +24,7 @@ const GridMixViewer: React.FC<Props> = ({
       </Alert>
     );
   }
-  return (
-    <Paper sx={{ p: 3, mt: 2 }}>
-      <Typography variant="h6" gutterBottom>
-        Grid Mix Data (Raw View)
-      </Typography>
-      <pre style={{ maxHeight: 300, overflow: "auto", textAlign: "left" }}>
-        {JSON.stringify(data.slice(0, 20), null, 2)}
-      </pre>
-    </Paper>
-  );
+  return <GridMixTable data={data} />;
 };
 
 export default GridMixViewer;


### PR DESCRIPTION
This PR introduces a responsive, accessible table to display electricity generation data by fuel type using Material UI components. The table includes columns for date, fuel type, and generation (MWh). Closes #23