### PR TITLE
Add Fuel Type Line Chart Visualization with Observable Plot

### DIFF
--- a/frontend/src/components/GridMixChart.tsx
+++ b/frontend/src/components/GridMixChart.tsx
@@ -89,34 +89,49 @@ const GridMixChart: React.FC<Props> = ({ data }) => {
           Generation Trends by Fuel Type
         </Typography>
 
-        <Grid container spacing={2}>
-          <Grid item xs={12} md={9}>
+        <Box
+          sx={{
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "center",
+            alignItems: "flex-start",
+            gap: 4,
+            maxWidth: 1000,
+            mx: "auto",
+          }}
+        >
+          <Box sx={{ flex: "1 1 600px", minWidth: "300px" }}>
             <Box ref={chartRef} sx={{ overflowX: "auto" }} />
-          </Grid>
+          </Box>
 
-          <Grid item xs={12} md={3}>
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-              {fuelLegend.map(({ label, color }) => (
+          <Box
+            sx={{
+              flex: "0 1 200px",
+              display: "flex",
+              flexDirection: "column",
+              gap: 1,
+            }}
+          >
+            {fuelLegend.map(({ label, color }) => (
+              <Box
+                key={label}
+                sx={{ display: "flex", alignItems: "center", gap: 1 }}
+              >
                 <Box
-                  key={label}
-                  sx={{ display: "flex", alignItems: "center", gap: 1 }}
-                >
-                  <Box
-                    sx={{
-                      width: 14,
-                      height: 14,
-                      bgcolor: color,
-                      borderRadius: 0.5,
-                    }}
-                  />
-                  <Typography variant="body2" color="text.primary">
-                    {label}
-                  </Typography>
-                </Box>
-              ))}
-            </Box>
-          </Grid>
-        </Grid>
+                  sx={{
+                    width: 14,
+                    height: 14,
+                    bgcolor: color,
+                    borderRadius: 0.5,
+                  }}
+                />
+                <Typography variant="body2" color="text.primary">
+                  {label}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </Box>
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/GridMixChart.tsx
+++ b/frontend/src/components/GridMixChart.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useRef } from "react";
+import * as Plot from "@observablehq/plot";
+import { Box, Card, CardContent, Typography, Grid } from "@mui/material";
+
+interface GridDataPoint {
+  date: string | Date; // Can pass in ISO string or Date object
+  type_name: string;
+  generation_mwh: number;
+}
+
+interface Props {
+  data: GridDataPoint[];
+}
+
+const fuelLegend = [
+  { label: "Coal", color: "#d62728" },
+  { label: "Natural Gas", color: "#ff7f0e" },
+  { label: "Nuclear", color: "#2ca02c" },
+  { label: "Petroleum", color: "#8c564b" },
+  { label: "Other", color: "#7f7f7f" },
+  { label: "Solar", color: "#e377c2" },
+  { label: "Hydro", color: "#9467bd" },
+  { label: "Wind", color: "#1f77b4" },
+];
+
+const GridMixChart: React.FC<Props> = ({ data }) => {
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!data.length) return;
+
+    // Parse date strings if needed
+
+    const fuelTypes = [...new Set(data.map((d) => d.type_name))];
+    console.log("⚡ Unique fuel types in raw data:", fuelTypes);
+    const parsedData = data.map((d) => ({
+      ...d,
+      date: typeof d.date === "string" ? new Date(d.date) : d.date,
+    }));
+
+    const plot = Plot.plot({
+      width: 800,
+      height: 400,
+      marginLeft: 60,
+      x: {
+        label: "Date",
+        tickFormat: (d) =>
+          d.toLocaleDateString("en-US", { month: "short", year: "2-digit" }),
+
+        ticks: 12,
+      },
+      y: {
+        label: "Generation (MWh)",
+        grid: true,
+      },
+      color: {
+        type: "categorical",
+        legend: false,
+        label: "Fuel Type",
+        domain: fuelLegend.map((f) => f.label),
+        range: fuelLegend.map((f) => f.color),
+      },
+      marks: [
+        Plot.lineY(parsedData, {
+          x: "date",
+          y: "generation_mwh",
+          stroke: "type_name",
+          curve: "monotone-x",
+          strokeWidth: 2,
+          strokeOpacity: 0.9,
+        }),
+        Plot.ruleY([0], { stroke: "#666", strokeOpacity: 0.5 }),
+      ],
+    });
+
+    chartRef.current?.appendChild(plot);
+
+    console.log("parsedData sample:", parsedData.slice(0, 10));
+
+    return () => {
+      plot.remove();
+    };
+  }, [data]);
+
+  return (
+    <Card variant="outlined" sx={{ mt: 4 }}>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Generation Trends by Fuel Type
+        </Typography>
+
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={9}>
+            <Box ref={chartRef} sx={{ overflowX: "auto" }} />
+          </Grid>
+
+          <Grid item xs={12} md={3}>
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+              {fuelLegend.map(({ label, color }) => (
+                <Box
+                  key={label}
+                  sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                >
+                  <Box
+                    sx={{
+                      width: 14,
+                      height: 14,
+                      bgcolor: color,
+                      borderRadius: 0.5,
+                    }}
+                  />
+                  <Typography variant="body2" color="text.primary">
+                    {label}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default GridMixChart;

--- a/frontend/src/components/GridMixChart.tsx
+++ b/frontend/src/components/GridMixChart.tsx
@@ -30,9 +30,6 @@ const GridMixChart: React.FC<Props> = ({ data }) => {
     if (!data.length) return;
 
     // Parse date strings if needed
-
-    const fuelTypes = [...new Set(data.map((d) => d.type_name))];
-    console.log("⚡ Unique fuel types in raw data:", fuelTypes);
     const parsedData = data.map((d) => ({
       ...d,
       date: typeof d.date === "string" ? new Date(d.date) : d.date,
@@ -74,8 +71,6 @@ const GridMixChart: React.FC<Props> = ({ data }) => {
     });
 
     chartRef.current?.appendChild(plot);
-
-    console.log("parsedData sample:", parsedData.slice(0, 10));
 
     return () => {
       plot.remove();

--- a/frontend/src/components/GridMixChart.tsx
+++ b/frontend/src/components/GridMixChart.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import * as Plot from "@observablehq/plot";
-import { Box, Card, CardContent, Typography, Grid } from "@mui/material";
+import { Box, Card, CardContent, Typography } from "@mui/material";
 
 interface GridDataPoint {
   date: string | Date; // Can pass in ISO string or Date object

--- a/frontend/src/components/GridMixTable.tsx
+++ b/frontend/src/components/GridMixTable.tsx
@@ -12,12 +12,13 @@ import {
   Box,
 } from "@mui/material";
 import type { GridMixEntry } from "../types/gridMix";
+import type { Theme } from "@mui/material/styles";
 
 type Props = {
   data: GridMixEntry[];
 };
 
-const headerCellStyle = (theme) => ({
+const headerCellStyle = (theme: Theme) => ({
   fontWeight: "bold",
   backgroundColor:
     theme.palette.mode === "dark" ? theme.palette.grey[900] : "#f9f9f9",

--- a/frontend/src/components/GridMixTable.tsx
+++ b/frontend/src/components/GridMixTable.tsx
@@ -17,12 +17,15 @@ type Props = {
   data: GridMixEntry[];
 };
 
-const headerCellStyle = {
+const headerCellStyle = (theme) => ({
   fontWeight: "bold",
-  backgroundColor: "#f9f9f9",
-  borderBottom: "2px solid #ddd",
+  backgroundColor:
+    theme.palette.mode === "dark" ? theme.palette.grey[900] : "#f9f9f9",
+  color: theme.palette.text.primary,
+  borderBottom: "2px solid",
+  borderColor: theme.palette.divider,
   padding: "8px 16px",
-};
+});
 
 const cellStyle = {
   padding: "8px 16px",
@@ -72,7 +75,7 @@ const GridMixTable: React.FC<Props> = ({ data }) => {
             <TableRow>
               <TableCell
                 sortDirection={orderBy === "timestamp" ? order : false}
-                sx={{ ...headerCellStyle, pr: 4 }}
+                sx={(theme) => ({ ...headerCellStyle(theme), pr: 4 })}
               >
                 <Box display="flex" alignItems="center">
                   <TableSortLabel
@@ -87,7 +90,7 @@ const GridMixTable: React.FC<Props> = ({ data }) => {
 
               <TableCell
                 sortDirection={orderBy === "type-name" ? order : false}
-                sx={{ ...headerCellStyle, pr: 4 }}
+                sx={(theme) => ({ ...headerCellStyle(theme), pr: 4 })}
               >
                 <Box display="flex" alignItems="center">
                   <TableSortLabel
@@ -102,7 +105,7 @@ const GridMixTable: React.FC<Props> = ({ data }) => {
 
               <TableCell
                 sortDirection={orderBy === "Generation (MWh)" ? order : false}
-                sx={{ ...headerCellStyle, pr: 4 }}
+                sx={(theme) => ({ ...headerCellStyle(theme), pr: 4 })}
               >
                 <Box display="flex" alignItems="center">
                   <TableSortLabel

--- a/frontend/src/components/GridMixViewer.tsx
+++ b/frontend/src/components/GridMixViewer.tsx
@@ -1,6 +1,7 @@
-import { Alert, CircularProgress } from "@mui/material";
+import { Alert, CircularProgress, Box } from "@mui/material";
 import type { GridMixEntry } from "../types/gridMix";
 import GridMixTable from "./GridMixTable";
+import GridMixChart from "./GridMixChart";
 
 type Props = {
   data: GridMixEntry[];
@@ -24,7 +25,20 @@ const GridMixViewer: React.FC<Props> = ({
       </Alert>
     );
   }
-  return <GridMixTable data={data} />;
+
+  // Transform data for the chart
+  const chartData = data.map((entry) => ({
+    date: new Date(entry.timestamp),
+    type_name: entry["type-name"],
+    generation_mwh: entry["Generation (MWh)"],
+  }));
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <GridMixChart data={chartData} />
+      <GridMixTable data={data} />
+    </Box>
+  );
 };
 
 export default GridMixViewer;

--- a/frontend/src/components/GridMixViewer.tsx
+++ b/frontend/src/components/GridMixViewer.tsx
@@ -1,4 +1,4 @@
-import { Alert, CircularProgress, Box } from "@mui/material";
+import { Alert, CircularProgress, Box, Typography } from "@mui/material";
 import type { GridMixEntry } from "../types/gridMix";
 import GridMixTable from "./GridMixTable";
 import GridMixChart from "./GridMixChart";
@@ -16,9 +16,20 @@ const GridMixViewer: React.FC<Props> = ({
   error,
   selectedBA,
 }) => {
-  if (loading) return <CircularProgress sx={{ mt: 2, mb: 2 }} />;
+  if (loading) return <CircularProgress sx={{ mt: 4 }} />;
   if (error) return <Alert severity="error">{error}</Alert>;
-  if (selectedBA && data.length === 0) {
+
+  if (!selectedBA) {
+    return (
+      <Box sx={{ mt: 6, textAlign: "center", color: "text.secondary" }}>
+        <Typography variant="body1">
+          Select a balancing authority to view generation data.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (data.length === 0) {
     return (
       <Alert severity="info" sx={{ mt: 2, mb: 2 }}>
         No generation data available for the selected balancing authority.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,13 +2,24 @@ import React, { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "leaflet/dist/leaflet.css";
 import App from "./App";
+import { createTheme, ThemeProvider } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
+
+const darkTheme = createTheme({
+  palette: {
+    mode: "dark",
+  },
+});
 
 const rootElement = document.getElementById("root");
 
 if (rootElement) {
   createRoot(rootElement).render(
     <StrictMode>
-      <App />
+      <ThemeProvider theme={darkTheme}>
+        <CssBaseline />
+        <App />
+      </ThemeProvider>
     </StrictMode>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,505 @@
+{
+  "name": "electricity-demand-generation",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@observablehq/plot": "^0.6.17"
+      }
+    },
+    "node_modules/@observablehq/plot": {
+      "version": "0.6.17",
+      "resolved": "https://registry.npmjs.org/@observablehq/plot/-/plot-0.6.17.tgz",
+      "integrity": "sha512-/qaXP/7mc4MUS0s4cPPFASDRjtsWp85/TbfsciqDgU1HwYixbSbbytNuInD8AcTYC3xaxACgVX06agdfQy9W+g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "interval-tree-1d": "^1.0.0",
+        "isoformat": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/binary-search-bounds": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/interval-tree-1d": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.4.tgz",
+      "integrity": "sha512-wY8QJH+6wNI0uh4pDQzMvl+478Qh7Rl4qLmqiluxALlNvl+I+o5x38Pw3/z7mDPTPS1dQalZJXsmbvxx5gclhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.0"
+      }
+    },
+    "node_modules/isoformat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/isoformat/-/isoformat-0.2.1.tgz",
+      "integrity": "sha512-tFLRAygk9NqrRPhJSnNGh7g7oaVWDwR0wKh/GM2LgmPa50Eg4UfyaCO4I8k6EqJHl1/uh2RAD6g06n5ygEnrjQ==",
+      "license": "ISC"
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@observablehq/plot": "^0.6.17"
+  }
+}


### PR DESCRIPTION
This PR implements a responsive line chart using Observable Plot to visualize electricity generation by fuel type. The chart is integrated into the existing MUI layout and dynamically updates based on the selected balancing authority. Closes #24 

Features Implemented
Line chart built with @observablehq/plot, rendered via useRef and useEffect

Each line represents a distinct fuel type, using a consistent custom color palette

Integrated into the application layout using MUI Card and Box components

Fully supports dark mode with readable axes and labels

Chart and table are conditionally rendered only after a balancing authority is selected

A placeholder message is shown to guide the user before a selection is made

Technical Notes
type-name is used as the canonical fuel type for both chart and table

Chart rendering is skipped when no data is available or no BA is selected

Custom legend is included alongside the chart and matches the defined color domain